### PR TITLE
refactor: added py.typed

### DIFF
--- a/src/shinyreporter/Blocks.py
+++ b/src/shinyreporter/Blocks.py
@@ -2,48 +2,49 @@ from typing import List, Optional, Any, Dict
 
 __all__ = ["ContentBlock"]
 
+
 class ContentBlock:
     """
     A class representing a content block with various methods to set and retrieve content.
     """
-    
+
     def __init__(self):
         """
         Initializes an empty content block.
         """
         self._content: List[Any] = []
-        
+
     def set_content(self, content: Optional[Any]) -> None:
         """
         Sets the content of the content block.
-        
+
         Args:
             content (Optional[Any]): The content to be set. Can be of any type or None.
         """
         raise NotImplementedError("This method is not implemented.")
-        
+
     def get_content(self) -> str:
         """
         Retrieves the content of the content block.
-        
+
         Returns:
             str: The content as a string.
         """
         raise NotImplementedError("This method is not implemented.")
-        
+
     def from_list(self, x: Dict[str, Any]) -> None:
         """
         Sets the content of the content block from a dictionary.
-        
+
         Args:
             x (Dict[str, Any]): A dictionary with content data.
         """
         raise NotImplementedError("This method is not implemented.")
-        
+
     def to_list(self) -> Dict[str, Any]:
         """
         Converts the content block to a dictionary.
-        
+
         Returns:
             Dict[str, Any]: A dictionary representation of the content block.
         """

--- a/tests/test_contentblock.py
+++ b/tests/test_contentblock.py
@@ -1,21 +1,25 @@
 import pytest
 from shinyreporter.Blocks import ContentBlock
 
+
 def test_set_content():
     block = ContentBlock()
     with pytest.raises(NotImplementedError, match="This method is not implemented."):
         block.set_content("Hello, World!")
+
 
 def test_get_content():
     block = ContentBlock()
     with pytest.raises(NotImplementedError, match="This method is not implemented."):
         block.get_content()
 
+
 def test_from_list():
     block = ContentBlock()
     data = {"text": "Hello, World!"}
     with pytest.raises(NotImplementedError, match="This method is not implemented."):
         block.from_list(data)
+
 
 def test_to_list():
     block = ContentBlock()


### PR DESCRIPTION
* Apparently, if we want mimy and other modules to detect that the library uses typing, we should add an empty file - py.typed to the project.
* This is according to [PEP-561](https://peps.python.org/pep-0561/#packaging-type-information).
* I also reran the black formatter on the files, but I might have set it up wrong.